### PR TITLE
How to use 2nd level Cache in a a Java EE application server

### DIFF
--- a/cache2ndee/Dockerfile
+++ b/cache2ndee/Dockerfile
@@ -1,0 +1,7 @@
+FROM jboss/wildfly:18.0.0.Final
+
+MAINTAINER Joao Costa <costajlmpp@gmail.com>
+
+ENV DEPLOY_DIR /opt/jboss/wildfly/standalone/deployments/
+
+COPY ./target/cache2ndee.war $DEPLOY_DIR

--- a/cache2ndee/README.md
+++ b/cache2ndee/README.md
@@ -1,0 +1,11 @@
+# How to use 2nd level Cache in a a Java EE application server
+
+The purpose of this example is to analyze the principles of using the 2nd cache level on a Java EE application server.
+All example was developed and demonstrated using wildfly 18.0.0 Final.
+
+## Build
+mvn clean package && docker build -t io.costax/cache2ndee .
+
+## RUN
+
+docker rm -f cache2ndee || true && docker run -d -p 8080:8080 -p 8787:8787 --name cache2ndee io.costax/cache2ndee 

--- a/cache2ndee/buildAndRun.sh
+++ b/cache2ndee/buildAndRun.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+mvn clean package && docker build -t io.costax/cache2ndee .
+docker rm -f cache2ndee || true && docker run -d -p 8080:8080 -p 8787:8787 --name cache2ndee io.costax/cache2ndee

--- a/cache2ndee/pom.xml
+++ b/cache2ndee/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.costax</groupId>
+    <artifactId>cache2ndee</artifactId>
+    <version>0.0.1</version>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>2.0.1</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.3.12.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <finalName>cache2ndee</finalName>
+    </build>
+    <properties>
+        <sourceEncoding>UTF-8</sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--<project.build.resourceEncoding>ISO-8859-1</project.build.resourceEncoding>-->
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>13</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+</project>

--- a/cache2ndee/src/main/java/io/costax/JAXRSConfiguration.java
+++ b/cache2ndee/src/main/java/io/costax/JAXRSConfiguration.java
@@ -1,0 +1,11 @@
+package io.costax;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * Configures a JAX-RS endpoint. Delete this class, if you are not exposing
+ * JAX-RS resources in your application.
+ */
+@ApplicationPath("resources")
+public class JAXRSConfiguration extends Application {}

--- a/cache2ndee/src/main/java/io/costax/caches/boundary/Cache2ndManager.java
+++ b/cache2ndee/src/main/java/io/costax/caches/boundary/Cache2ndManager.java
@@ -1,0 +1,93 @@
+package io.costax.caches.boundary;
+
+import io.costax.users.boundary.Users;
+import org.hibernate.Session;
+
+import javax.ejb.Stateless;
+import javax.persistence.Cache;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * Provides an API for querying/managing the second level cache regions.
+ *
+ * @see org.hibernate.Cache
+ */
+@Stateless
+public class Cache2ndManager {
+
+    @PersistenceContext
+    EntityManager em;
+
+    /**
+     * Clear the cache.
+     */
+    public void evictAllCache() {
+        final Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evictAll();
+    }
+
+    /**
+     * Remove the data for entities of the specified class (and its
+     * subclasses) from the cache.
+     *
+     * @param entityClass entity class
+     */
+    public void evictCacheForEntity(Class<?> entityClass) {
+        final Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(entityClass);
+    }
+
+    /**
+     * Remove the data for the given entity from the cache.
+     *
+     * @param entityClass entity class
+     * @param primaryKey  primary key
+     */
+    public void evictCacheForInstance(Class<?> entityClass, Object primaryKey) {
+        final Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(entityClass, primaryKey);
+    }
+
+    /**
+     * Whether the cache contains data for the given entity.
+     *
+     * @param entityClass entity class
+     * @param primaryKey  primary key
+     * @return boolean indicating whether the entity is in the cache
+     */
+    public boolean contains(Class<?> entityClass, Object primaryKey) {
+        final Cache cache = em.getEntityManagerFactory().getCache();
+        return cache.contains(entityClass, primaryKey);
+    }
+
+    /**
+     * Evict all data from the named cache region.
+     * <p>
+     * The regions are create in the Query execution eg.
+     * <p>
+     * {@code .setHint(QueryHints.HINT_CACHE_REGION, "home")}
+     *
+     * @param regionName regions Name that should be clean
+     * @see {@link Users#list()}
+     */
+    public void evictRegion(String regionName) {
+        final org.hibernate.Cache cache = em.unwrap(Session.class).getSessionFactory().getCache();
+        // clean regions home of the cache
+        cache.evictRegion(regionName);
+
+        // NOTE:
+        // How to create the regions? See the Users#list() method please...
+    }
+
+    /**
+     * Evict data from all cache regions.
+     */
+    public void evictAllRegions() {
+        final org.hibernate.Cache cache = em.unwrap(Session.class).getSessionFactory().getCache();
+        // clean all region
+        cache.evictAllRegions();
+    }
+
+
+}

--- a/cache2ndee/src/main/java/io/costax/caches/boundary/Cache2ndResource.java
+++ b/cache2ndee/src/main/java/io/costax/caches/boundary/Cache2ndResource.java
@@ -1,0 +1,18 @@
+package io.costax.caches.boundary;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+@Path("/cache-2nd")
+public class Cache2ndResource {
+
+    @Inject
+    Cache2ndManager cache2ndManager;
+
+    @POST
+    @Path("/evict-all")
+    public void evictAll() {
+        cache2ndManager.evictAllCache();
+    }
+}

--- a/cache2ndee/src/main/java/io/costax/jsonb/FieldAccessStrategy.java
+++ b/cache2ndee/src/main/java/io/costax/jsonb/FieldAccessStrategy.java
@@ -1,0 +1,32 @@
+package io.costax.jsonb;
+
+import javax.json.bind.annotation.JsonbTransient;
+import javax.json.bind.config.PropertyVisibilityStrategy;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class FieldAccessStrategy implements PropertyVisibilityStrategy {
+
+    @Override
+    public boolean isVisible(Field field) {
+        if (field.getName().startsWith("_persistence_")) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isVisible(Method method) {
+        return isPublicOrProtectedGetterMethod(method);
+    }
+
+    private static boolean isPublicOrProtectedGetterMethod(Method method){
+        if (!method.getName().startsWith("get")) return false;
+        if (method.getParameterTypes().length != 0) return false;
+        if (void.class.equals(method.getReturnType())) return false;
+        if (method.isAnnotationPresent(JsonbTransient.class)) return false;
+        return Modifier.isProtected(method.getModifiers()) || Modifier.isPublic(method.getModifiers());
+    }
+
+}

--- a/cache2ndee/src/main/java/io/costax/jsonb/JsonB.java
+++ b/cache2ndee/src/main/java/io/costax/jsonb/JsonB.java
@@ -1,0 +1,24 @@
+package io.costax.jsonb;
+
+
+import javax.json.bind.annotation.JsonbAnnotation;
+import javax.json.bind.annotation.JsonbNillable;
+import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.json.bind.annotation.JsonbVisibility;
+import javax.json.bind.config.PropertyOrderStrategy;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+
+@Documented
+@JsonbAnnotation
+@JsonbNillable(true)
+@JsonbPropertyOrder(PropertyOrderStrategy.LEXICOGRAPHICAL)
+@JsonbVisibility(FieldAccessStrategy.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ANNOTATION_TYPE, TYPE, PACKAGE})
+public @interface JsonB {
+}

--- a/cache2ndee/src/main/java/io/costax/ping/boundary/PingResource.java
+++ b/cache2ndee/src/main/java/io/costax/ping/boundary/PingResource.java
@@ -1,0 +1,21 @@
+package io.costax.ping.boundary;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("ping")
+public class PingResource {
+
+	@Inject
+    @ConfigProperty(name = "message")
+    String message;    
+
+    @GET
+    public String ping() {
+        return this.message + " Java EE 8!";
+    }
+
+}

--- a/cache2ndee/src/main/java/io/costax/users/boundary/UserResources.java
+++ b/cache2ndee/src/main/java/io/costax/users/boundary/UserResources.java
@@ -1,0 +1,54 @@
+package io.costax.users.boundary;
+
+import io.costax.users.entity.User;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.List;
+
+@Path("/users")
+@Produces({MediaType.APPLICATION_JSON})
+public class UserResources {
+
+    @Inject
+    Users users;
+
+    @Context
+    UriInfo uriInfo;
+
+    @GET
+    public List<User> list() {
+        return users.list();
+    }
+
+    @GET
+    @Path("/{id: \\d+}")
+    public Response getUser(@PathParam("id") Long id) {
+        final User user = users.getById(id);
+
+        if (user == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                .header("X-reason", String.format("Resource [%s] with identifier [%d] not found", User.class.getSimpleName(), id))
+                .build();
+        }
+
+        return Response.ok(user).build();
+    }
+
+    @POST
+    public Response add(@Valid User user) {
+        final User added = users.add(user);
+
+        final URI uri = uriInfo.getAbsolutePathBuilder().path("{id}").build(added.getId());
+
+        return Response.created(uri).entity(added).build();
+    }
+
+
+}

--- a/cache2ndee/src/main/java/io/costax/users/boundary/Users.java
+++ b/cache2ndee/src/main/java/io/costax/users/boundary/Users.java
@@ -1,0 +1,72 @@
+package io.costax.users.boundary;
+
+import io.costax.users.entity.User;
+import org.hibernate.jpa.QueryHints;
+
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Stateless
+public class Users {
+
+    @PersistenceContext
+    EntityManager em;
+
+    // NOTES: We can not declare the TransactionAttributeType.SUPPORTS, it must be leaved as default or without any annotation (REQUIRED)
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public List<User> list() {
+        final List<User> users = em.createQuery("select u from User u left join fetch u.permissions order by u.id desc", User.class)
+                .setHint(QueryHints.HINT_CACHEABLE, true)
+                // NOTES:
+                // For the purpose of the current example, it is not mandatory or required to use regions.
+                // I'm using it just for the sake of coaching.
+                // The region name can be any name we want, ex. Home-page, Top10, etc.
+                .setHint(QueryHints.HINT_CACHE_REGION, "home")
+                .getResultList();
+
+        // NOTES:
+        // This is the necessary workaround to ensure that all permissions entities are not proxies instances :(
+        // We need to use one of the fowling options, I prefer the first one because it not requires a hibernate import
+        users.forEach(user -> user.getPermissions().size());
+        //users.forEach(user -> Hibernate.initialize(user.getPermissions()));
+
+        return users;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public User add(User user) {
+        final User merge = em.merge(user);
+
+        em.flush();
+
+        return merge;
+    }
+
+    public User getById(final Long id) {
+        final EntityGraph<User> entityGraph = em.createEntityGraph(User.class);
+        entityGraph.addAttributeNodes("permissions");
+
+        final User user = em
+                .find(User.class,
+                        id,
+                        Map.of(
+                                org.hibernate.annotations.QueryHints.LOADGRAPH, entityGraph,
+                                org.hibernate.annotations.QueryHints.CACHEABLE, true));
+
+        // NOTES:
+        // This is the necessary workaround to ensure that all permissions entities are not proxies instances :(
+        // We need to use one of the fowling options, I prefer the first one because it not requires a hibernate import
+        //users.forEach(user -> user.getPermissions().size());
+        //users.forEach(user -> Hibernate.initialize(user.getPermissions()));
+        Optional.ofNullable(user).ifPresent(u -> u.getPermissions().size());
+
+        return user;
+    }
+}

--- a/cache2ndee/src/main/java/io/costax/users/entity/Permission.java
+++ b/cache2ndee/src/main/java/io/costax/users/entity/Permission.java
@@ -1,0 +1,63 @@
+package io.costax.users.entity;
+
+import io.costax.jsonb.JsonB;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+@JsonB
+@Entity
+@Cacheable
+//@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class Permission {
+
+    @Id
+    @NotNull
+    @Column(name = "id", nullable = false, unique = true)
+    private Integer id;
+    @NotBlank
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Deprecated
+    public Permission() {
+    }
+
+    private Permission(final Integer id, final String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static Permission of(final Integer id, final String name) {
+        if (id == null) throw new IllegalArgumentException("the permission id should not be null");
+        if (name == null) throw new IllegalArgumentException("the permission name should not be null");
+
+        return new Permission(id, name);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Permission)) return false;
+        final Permission that = (Permission) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/cache2ndee/src/main/java/io/costax/users/entity/User.java
+++ b/cache2ndee/src/main/java/io/costax/users/entity/User.java
@@ -1,0 +1,80 @@
+package io.costax.users.entity;
+
+import io.costax.jsonb.JsonB;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@JsonB
+@Entity
+@Cacheable
+//@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, updatable = false)
+    private Long id;
+
+    @NotBlank
+    private String name;
+
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(name = "user_permission",
+            joinColumns = @JoinColumn(name = "user_id", nullable = false, updatable = false),
+            inverseJoinColumns = @JoinColumn(name = "permission_id", nullable = false, updatable = false)
+    )
+    private Set<Permission> permissions = new HashSet<>();
+
+    @Deprecated
+    protected User() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User)) return false;
+        final User user = (User) o;
+        return getId() != null && Objects.equals(getId(), user.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return 31;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+
+    public Set<Permission> getPermissions() {
+        return Set.copyOf(permissions);
+    }
+
+    public User addPermission(Permission permission) {
+        this.permissions.add(permission);
+        return this;
+    }
+
+    public User removePermission(Permission permission) {
+        this.permissions.remove(permission);
+        return this;
+    }
+}

--- a/cache2ndee/src/main/resources/META-INF/import.sql
+++ b/cache2ndee/src/main/resources/META-INF/import.sql
@@ -1,0 +1,11 @@
+insert into permission (id, name) values (1, 'CREATE_BLOG');
+insert into permission (id, name) values (2, 'READ');
+insert into permission (id, name) values (3, 'WRITE');
+
+insert into user (id, name) values (1001, 'Joana');
+insert into user (id, name) values (1002, 'Rodrigo');
+
+insert into user_permission(user_id, permission_id) values (1001, 1);
+insert into user_permission(user_id, permission_id) values (1001, 2);
+insert into user_permission(user_id, permission_id) values (1001, 3);
+insert into user_permission(user_id, permission_id) values (1002, 2);

--- a/cache2ndee/src/main/resources/META-INF/microprofile-config.properties
+++ b/cache2ndee/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,2 @@
+# microprofile-config.properties
+message=Enjoy

--- a/cache2ndee/src/main/resources/META-INF/persistence.xml
+++ b/cache2ndee/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<persistence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
+             version="2.2">
+    <persistence-unit name="dev" transaction-type="JTA">
+        <jta-data-source>java:comp/DefaultDataSource</jta-data-source>
+        <!--<jta-data-source>jdbc/__default</jta-data-source>-->
+        <!--<jta-data-source>jdbc/__postgres</jta-data-source>-->
+
+        <!--
+          - We need to provide the **shared-cache-mode** when we active the 2nd level cache, this configuration defines with entities should be cached. We can choose 4 different modes:
+                - **ALL**  - cache all entities, not recommended
+                - **NONE** - cache no entities, not recommended
+                - **ENABLE_SELECTIVE**
+                    cache needs to be activated for specific entities
+                    the most commonly used mode is enable_selected, which allows you to define exactly which entities should be cached. this makes much more sense than to cache everything, because we do not get cache for free, it requires memory to store the entities and CPU time to manager the cache, so to use it we must have absolutely sure that the benefits of having a cached entity are higher than directly accessing the Database.
+                    this is only the case when the entity is only read without being changed.
+                    Entities that are not read from the cache only consumes memory, and if it is necessary to update the caches it will consumes time.
+                - **DISABLE_SELECTIVE**
+                    cache can be deactivated for specific entities
+        -->
+        <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
+        <!-- Validation modes: AUTO, CALLBACK, NONE -->
+        <validation-mode>AUTO</validation-mode>
+
+        <properties>
+
+            <!--
+             javax.persistence.schema-generation.database.action
+             Defines whether the persistence provider shall create the database, first drop and then recreate it, only drop it or do nothing at all.
+             If this property is not provided, no schema will be created.
+             [none, create, drop-and-create, drop]
+             <property name="javax.persistence.schema-generation.database.action" value="none"/>
+             -->
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+            <!-- property name="javax.persistence.schema-generation.create-source" value="script"/ -->
+            <!-- property name="javax.persistence.schema-generation.create-script-source" value="META-INF/create.sql"/ -->
+            <!-- property name="javax.persistence.schema-generation.drop-source" value="script"/ -->
+            <!-- property name="javax.persistence.schema-generation.drop-script-source" value="META-INF/drop.sql"/> -->
+
+            <property name="javax.persistence.sql-load-script-source" value="META-INF/import.sql"/>
+            <property name="hibernate.generate_statistics" value="true"/>
+
+            <!-- Hibernate-->
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.show_sql" value="true"/>
+            <!-- property name = "hibernate.use_sql_comments" value = "true" / -->
+
+            <!-- in wildfly is active by default: https://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/chapters/caching/Caching.html-->
+            <!--property name="hibernate.cache.use_second_level_cache" value="true"/-->
+
+            <property name="hibernate.cache.use_query_cache" value="true"/>
+            <!--Max time in millis one entity is in the cache-->
+            <property name="hibernate.cache.infinispan.entity.expiration.lifespan" value= "900000"/><!--in millis - 15min-->
+            <!--Max time one entity not used (IDLE) can be in the cache -->
+            <property name="hibernate.cache.infinispan.entity.expiration.max_idle" value= "300000"/><!--in millis -  5min-->
+            <property name="hibernate.cache.infinispan.entity.eviction.strategy" value= "LRU"/>
+            <property name="hibernate.cache.infinispan.entity.eviction.wake_up_interval" value= "2000"/>
+            <property name="hibernate.cache.infinispan.entity.eviction.max_entries" value= "5000"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/cache2ndee/src/main/webapp/WEB-INF/beans.xml
+++ b/cache2ndee/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2.0.xsd"
+       bean-discovery-mode="all" 
+       version="2.0">
+</beans>

--- a/cache2ndee/src/main/webapp/index.html
+++ b/cache2ndee/src/main/webapp/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>cache2ndee</title>
+</head>
+<body>
+    Hello cache2ndee.
+</body>
+</html>

--- a/cache2ndee/src/test/java/io/costax/ping/boundary/PingResourceTest.java
+++ b/cache2ndee/src/test/java/io/costax/ping/boundary/PingResourceTest.java
@@ -1,0 +1,3 @@
+package io.costax.ping.boundary;
+
+public class PingResourceTest {}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>advanced-topics</module>
         <module>bytecode-enhancement-dirty-checking</module>
         <module>caches</module>
+        <module>cache2ndee</module>
         <module>bulk-operations</module>
         <module>batching-of-write-operations</module>
         <module>concurrency</module>


### PR DESCRIPTION
The purpose of this example is to analyze the principles of using the 2nd cache level in a Java EE application server.
All example was developed and demonstrated using wildfly 18.0.0 Final.